### PR TITLE
Fix Python 3.13 installation failures and Windows build errors (#89)

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,122 @@
+\# Installation Guide
+
+
+
+\## Python Version Support
+
+✅ \*\*Supported\*\*: Python 3.8, 3.9, 3.10, 3.11, 3.12  
+
+❌ \*\*Not supported\*\*: Python 3.13 (dependency conflicts)
+
+
+
+\## Quick Installation
+
+\# Installation Guide
+
+
+
+\## Python Version Support
+
+✅ \*\*Supported\*\*: Python 3.8, 3.9, 3.10, 3.11, 3.12  
+
+❌ \*\*Not supported\*\*: Python 3.13 (dependency conflicts)
+
+
+
+\## Quick Installation
+
+pip install recognizer
+
+
+
+text
+
+
+
+\## Windows Installation Issues
+
+
+
+\### Error: "numpy metadata generation failed"
+
+Fix: Install numpy first
+
+pip install "numpy<2.0.0"
+
+pip install recognizer
+
+
+
+text
+
+
+
+\### Error: "Unknown compiler(s)"  
+
+Fix: Use binary packages only
+
+pip install --only-binary=all recognizer
+
+
+
+text
+
+
+
+\### Alternative: Install Build Tools
+
+1\. Download \[Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+
+2\. Install "C++ build tools" workload  
+
+3\. Restart PowerShell
+
+4\. Run: `pip install recognizer`
+
+
+
+\## Python 3.13 Users
+
+Switch to Python 3.12:
+
+
+
+\*\*Using conda:\*\*
+
+conda create -n recognizer python=3.12
+
+conda activate recognizer
+
+pip install recognizer
+
+
+
+text
+
+
+
+\*\*Using pyenv (Linux/Mac):\*\*
+
+pyenv install 3.12.0
+
+pyenv local 3.12.0
+
+pip install recognizer
+
+
+
+text
+
+
+
+\## Verification
+
+python -c "import recognizer; print('✅ Success!')"
+
+
+
+text
+
+undefined
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,39 @@
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "recognizer"
+description = "Gracefully face reCAPTCHA challenges with YOLO/CLIP via Playwright or an easy API"
+readme = "README.md"
+license = {text = "GPL-3.0"}
+requires-python = ">=3.8,<3.13"
+authors = [{name = "Vinyzu"}]
+version = "1.4.0"
+classifiers = [
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9", 
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+]
+
+dependencies = [
+    "numpy>=1.21.0,<2.0.0",
+    "opencv-python>=4.10.0,<5.0.0", 
+    "pillow>=8.3.2,<12.0.0",
+    "imageio>=2.36.1,<3.0.0",
+    "ultralytics>=8.3.0,<8.3.50", 
+    "transformers>=4.48.0,<5.0.0",
+    "playwright>=1.49.1,<2.0.0",
+    "patchright>=1.49.1,<2.0.0"
+]
+
+[project.urls]
+Homepage = "https://github.com/Vinyzu/recognizer"
+Repository = "https://github.com/Vinyzu/recognizer"
+Issues = "https://github.com/Vinyzu/recognizer/issues"
+
 [tool.pytest.ini_options]
 testpaths = [
     "tests",
@@ -33,5 +66,4 @@ line_length = 200
 multi_line_output = 7
 
 [tool.ruff]
-# Allow lines to be as long as 120.
 line-length = 200

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,1 @@
-setuptools~=75.8.0
-opencv-python~=4.10.0.84
-imageio~=2.36.1
-ultralytics~=8.3.59
-transformers~=4.48.0
-playwright~=1.49.1
-patchright~=1.49.1
+.


### PR DESCRIPTION
## Summary
Resolves installation failures on Python 3.13 and Windows systems by adding proper dependency constraints and build configuration.

## Changes Made
✅ Added [project] metadata with `requires-python = ">=3.8,<3.13"`  
✅ Pinned numpy <2.0.0 to prevent Meson source builds on Windows
✅ Constrained ultralytics <8.3.50 to eliminate dependency backtracking
✅ Added pillow dependency explicitly  
✅ Created INSTALLATION.md with Windows-specific troubleshooting
✅ Fixed dynamic version configuration issue
✅ Moved runtime dependencies to pyproject.toml for proper package metadata

## Testing
- [x] Tested installation in clean virtual environment
- [x] Verified package imports successfully
- [x] Confirmed proper dependency resolution
- [x] Added Windows-specific installation guidance

## Before/After
**Before**: Installation failed with compiler errors and Python 3.13 compatibility issues  
**After**: Clean installation with clear version requirements and Windows guidance

## Fixes
Closes #89
